### PR TITLE
Avoid error thrown by BigNumber due to too many significant numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+Unreleased
+-----------
+
+### Fixed
+
+- throw if an error is less than `MIN_SAFE_INTEGER` or greater than `MAX_SAFE_INTEGER`. [#11], [#15]
+
+
 0.11.0 / 2016-06-06
 -------------------
 ### Added

--- a/lib/number-unit.js
+++ b/lib/number-unit.js
@@ -42,6 +42,11 @@ var NumberUnit = function () {
 
     // assert(unit instanceof Unit, 'Must specify type of Unit.')
     this._number = new _bignumber2.default(number);
+    var maxSafeInteger = new _bignumber2.default(Number.MAX_SAFE_INTEGER !== undefined ? Number.MAX_SAFE_INTEGER : 9007199254740991);
+    var minSafeInteger = new _bignumber2.default(Number.MIN_SAFE_INTEGER !== undefined ? Number.MIN_SAFE_INTEGER : -9007199254740991);
+    if (this._number.greaterThan(maxSafeInteger) || this._number.lessThan(minSafeInteger)) {
+      throw new Error('Number cannot be larger than ' + Number.MAX_SAFE_INTEGER + ' or less than ' + Number.MIN_SAFE_INTEGER);
+    }
     this.unit = unit;
 
     // TODO: make these getters

--- a/src/number-unit.js
+++ b/src/number-unit.js
@@ -15,7 +15,7 @@ export default class NumberUnit {
 
   constructor (number, unit, { strict } = {}) {
     // assert(unit instanceof Unit, 'Must specify type of Unit.')
-    this._number = new Decimal(number)
+    this._number = new Decimal(+('' + number) === 0 ? number : ('' + number))
     let maxSafeInteger = new Decimal(Number.MAX_SAFE_INTEGER !== undefined ? Number.MAX_SAFE_INTEGER : 9007199254740991)
     let minSafeInteger = new Decimal(Number.MIN_SAFE_INTEGER !== undefined ? Number.MIN_SAFE_INTEGER : -9007199254740991)
     if (this._number.greaterThan(maxSafeInteger) || this._number.lessThan(minSafeInteger)) {

--- a/src/number-unit.js
+++ b/src/number-unit.js
@@ -16,8 +16,8 @@ export default class NumberUnit {
   constructor (number, unit, { strict } = {}) {
     // assert(unit instanceof Unit, 'Must specify type of Unit.')
     this._number = new Decimal(number)
-    let maxSafeInteger = new Decimal(Number.MAX_SAFE_INTEGER)
-    let minSafeInteger = new Decimal(Number.MIN_SAFE_INTEGER)
+    let maxSafeInteger = new Decimal(Number.MAX_SAFE_INTEGER !== undefined ? Number.MAX_SAFE_INTEGER : 9007199254740991)
+    let minSafeInteger = new Decimal(Number.MIN_SAFE_INTEGER !== undefined ? Number.MIN_SAFE_INTEGER : -9007199254740991)
     if (this._number.greaterThan(maxSafeInteger) || this._number.lessThan(minSafeInteger)) {
       throw new Error('Number cannot be larger than ' + Number.MAX_SAFE_INTEGER + ' or less than ' + Number.MIN_SAFE_INTEGER)
     }

--- a/src/number-unit.js
+++ b/src/number-unit.js
@@ -16,6 +16,11 @@ export default class NumberUnit {
   constructor (number, unit, { strict } = {}) {
     // assert(unit instanceof Unit, 'Must specify type of Unit.')
     this._number = new Decimal(number)
+    let maxSafeInteger = new Decimal(Number.MAX_SAFE_INTEGER)
+    let minSafeInteger = new Decimal(Number.MIN_SAFE_INTEGER)
+    if (this._number.greaterThan(maxSafeInteger) || this._number.lessThan(minSafeInteger)) {
+      throw new Error('Number cannot be larger than ' + Number.MAX_SAFE_INTEGER + ' or less than ' + Number.MIN_SAFE_INTEGER)
+    }
     this.unit = unit
 
     // TODO: make these getters

--- a/tests/number-unit_safe-integer.test.js
+++ b/tests/number-unit_safe-integer.test.js
@@ -7,10 +7,13 @@ test('should not error out on significant figures', function (t) {
     return x !== undefined && x !== null && x.constructor && x.constructor.name === NumberUnit.name
   }
 
+  const maxSafeInteger = Number.MAX_SAFE_INTEGER !== undefined ? Number.MAX_SAFE_INTEGER : 9007199254740991
+  const minSafeInteger = Number.MIN_SAFE_INTEGER !== undefined ? Number.MIN_SAFE_INTEGER : -9007199254740991
+
   let b1 = null
   let error1 = false
   try {
-    b1 = bitcoin.BTC(Number.MAX_SAFE_INTEGER)
+    b1 = bitcoin.BTC(maxSafeInteger)
   } catch (e) {
     error1 = true
   }
@@ -19,7 +22,7 @@ test('should not error out on significant figures', function (t) {
   let b2 = null
   let error2 = false
   try {
-    b2 = bitcoin.BTC(Number.MAX_SAFE_INTEGER + 1)
+    b2 = bitcoin.BTC(maxSafeInteger + 1)
   } catch (e) {
     error2 = true
   }
@@ -28,7 +31,7 @@ test('should not error out on significant figures', function (t) {
   let b3 = null
   let error3 = false
   try {
-    b3 = bitcoin.BTC(Number.MAX_SAFE_INTEGER + '.1')
+    b3 = bitcoin.BTC(maxSafeInteger + '.1')
   } catch (e) {
     error3 = true
   }
@@ -37,7 +40,7 @@ test('should not error out on significant figures', function (t) {
   let b4 = null
   let error4 = false
   try {
-    b4 = bitcoin.BTC(Number.MIN_SAFE_INTEGER)
+    b4 = bitcoin.BTC(minSafeInteger)
   } catch (e) {
     error4 = true
   }
@@ -46,7 +49,7 @@ test('should not error out on significant figures', function (t) {
   let b5 = null
   let error5 = false
   try {
-    b5 = bitcoin.BTC(Number.MIN_SAFE_INTEGER - 1)
+    b5 = bitcoin.BTC(minSafeInteger - 1)
   } catch (e) {
     error5 = true
   }

--- a/tests/number-unit_safe-integer.test.js
+++ b/tests/number-unit_safe-integer.test.js
@@ -1,0 +1,56 @@
+import test from 'tape-catch'
+import { bitcoin } from './_fixtures'
+import NumberUnit from '../'
+
+test('should not error out on significant figures', function (t) {
+  let isNumberUnit = function (x) {
+    return x !== undefined && x !== null && x.constructor && x.constructor.name === NumberUnit.name
+  }
+
+  let b1 = null
+  let error1 = false
+  try {
+    b1 = bitcoin.BTC(Number.MAX_SAFE_INTEGER)
+  } catch (e) {
+    error1 = true
+  }
+  t.ok(error1 === false && isNumberUnit(b1), 'Creation of NumberUnit with number Number.MAX_SAFE_INTEGER was successful')
+
+  let b2 = null
+  let error2 = false
+  try {
+    b2 = bitcoin.BTC(Number.MAX_SAFE_INTEGER + 1)
+  } catch (e) {
+    error2 = true
+  }
+  t.ok(error2 === true && !isNumberUnit(b2), 'Creation of NumberUnit with number (Number.MAX_SAFE_INTEGER + 1) should throw an error')
+
+  let b3 = null
+  let error3 = false
+  try {
+    b3 = bitcoin.BTC(Number.MAX_SAFE_INTEGER + '.1')
+  } catch (e) {
+    error3 = true
+  }
+  t.ok(error3 === true && !isNumberUnit(b3), 'Creation of NumberUnit with number (Number.MAX_SAFE_INTEGER + .1) should throw an error')
+
+  let b4 = null
+  let error4 = false
+  try {
+    b4 = bitcoin.BTC(Number.MIN_SAFE_INTEGER)
+  } catch (e) {
+    error4 = true
+  }
+  t.ok(error4 === false && isNumberUnit(b4), 'Creation of NumberUnit with number Number.MIN_SAFE_INTEGER was successful')
+
+  let b5 = null
+  let error5 = false
+  try {
+    b5 = bitcoin.BTC(Number.MIN_SAFE_INTEGER - 1)
+  } catch (e) {
+    error5 = true
+  }
+  t.ok(error5 === true && !isNumberUnit(b5), 'Creation of NumberUnit with number (Number.MIN_SAFE_INTEGER - 1) should throw an error')
+
+  t.end()
+})

--- a/tests/number-unit_significant-figures.test.js
+++ b/tests/number-unit_significant-figures.test.js
@@ -1,39 +1,22 @@
 import test from 'tape-catch'
 import { bitcoin } from './_fixtures'
-import NumberUnit from '../'
 
 test('should not error out on significant figures', function (t) {
-  let isNumberUnit = function (x) {
-    return x !== undefined && x !== null && x.constructor && x.constructor.name === NumberUnit.name
-  }
+  t.doesNotThrow(function () {
+    bitcoin.BTC(3516.2695380859077) // 17 significant figures
+  }, 'Creation of NumberUnit with number 3516.2695380859077 should not throw an error')
 
-  let b1 = null
-  try {
-    b1 = bitcoin.BTC(3516.2695380859077) // 17 significant figures
-  } catch (e) {
-  }
-  t.ok(isNumberUnit(b1), 'Creation of NumberUnit with number 3516.2695380859077 was successful')
+  t.doesNotThrow(function () {
+    bitcoin.BTC(3516.26953808590) // 15 significant figures
+  }, 'Creation of NumberUnit with number 3516.26953808590 should not throw an error')
 
-  let b2 = null
-  try {
-    b2 = bitcoin.BTC(3516.26953808590) // 15 significant figures
-  } catch (e) {
-  }
-  t.ok(isNumberUnit(b2), 'Creation of NumberUnit with number 3516.26953808590 was successful')
+  t.doesNotThrow(function () {
+    bitcoin.BTC(351626953808590.7) // 16 significant figures
+  }, 'Creation of NumberUnit with number 351626953808590.7 should not throw an error')
 
-  let b3 = null
-  try {
-    b3 = bitcoin.BTC(351626953808590.7) // 16 significant figures
-  } catch (e) {
-  }
-  t.ok(isNumberUnit(b3), 'Creation of NumberUnit with number 351626953808590.7 was successful')
-
-  let b4 = null
-  try {
-    b4 = bitcoin.BTC(35162695380859.1) // 15 significant figures
-  } catch (e) {
-  }
-  t.ok(isNumberUnit(b4), 'Creation of NumberUnit with number 35162695380859.1 was successful')
+  t.doesNotThrow(function () {
+    bitcoin.BTC(35162695380859.1) // 15 significant figures
+  }, 'Creation of NumberUnit with number 35162695380859.1 should not throw an error')
 
   t.end()
 })

--- a/tests/number-unit_significant-figures.test.js
+++ b/tests/number-unit_significant-figures.test.js
@@ -1,0 +1,39 @@
+import test from 'tape-catch'
+import { bitcoin } from './_fixtures'
+import NumberUnit from '../'
+
+test('should not error out on significant figures', function (t) {
+  let isNumberUnit = function (x) {
+    return x !== undefined && x !== null && x.constructor && x.constructor.name === NumberUnit.name
+  }
+
+  let b1 = null
+  try {
+    b1 = bitcoin.BTC(3516.2695380859077) // 17 significant figures
+  } catch (e) {
+  }
+  t.ok(isNumberUnit(b1), 'Creation of NumberUnit with number 3516.2695380859077 was successful')
+
+  let b2 = null
+  try {
+    b2 = bitcoin.BTC(3516.26953808590) // 15 significant figures
+  } catch (e) {
+  }
+  t.ok(isNumberUnit(b2), 'Creation of NumberUnit with number 3516.26953808590 was successful')
+
+  let b3 = null
+  try {
+    b3 = bitcoin.BTC(351626953808590.7) // 16 significant figures
+  } catch (e) {
+  }
+  t.ok(isNumberUnit(b3), 'Creation of NumberUnit with number 351626953808590.7 was successful')
+
+  let b4 = null
+  try {
+    b4 = bitcoin.BTC(35162695380859.1) // 15 significant figures
+  } catch (e) {
+  }
+  t.ok(isNumberUnit(b4), 'Creation of NumberUnit with number 35162695380859.1 was successful')
+
+  t.end()
+})


### PR DESCRIPTION
Fixes #1

To avoid error from BigNumber on number with more than 15 significant figures, pass it as string but doing so will fail -0 'is negative' test because -0.toString() is '0', so make zero as an exception